### PR TITLE
Feature/tc caching

### DIFF
--- a/base/src/main/scala/TCUBase.scala
+++ b/base/src/main/scala/TCUBase.scala
@@ -14,10 +14,11 @@ object TCUBase {
       type T[X] = T0[B0, X]
       type A = A0
     } = new TCU[C, T0[B0, A0]] {
-      type T[X] = T0[B0, X]
-      type A = A0
-      val instance: C[T] = TC0.instance.asInstanceOf[C[T]]
-      val leibniz: T0[B0, A0] === T[A] = Leibniz.refl
+      override type T[X] = T0[B0, X]
+      override type A = A0
+      override val instance = TC0.instance.asInstanceOf[C[T]]
+      override val instanceTag = TC0.instanceTag
+      override val leibniz: T0[B0, A0] === T[A] = Leibniz.refl
     }
 
     // OptionT
@@ -27,10 +28,11 @@ object TCUBase {
       type T[X] = T0[F, X]
       type A = A0
     } = new TCU[C, T0[F, A0]] {
-      type T[X] = T0[F, X]
-      type A = A0
-      val instance: C[T] = TC0.instance.asInstanceOf[C[T]]
-      val leibniz: T0[F, A0] === T[A] = Leibniz.refl
+      override type T[X] = T0[F, X]
+      override type A = A0
+      override val instance = TC0.instance.asInstanceOf[C[T]]
+      override val instanceTag = TC0.instanceTag
+      override val leibniz: T0[F, A0] === T[A] = Leibniz.refl
     }
   }
 }

--- a/base/src/main/scala/TCUBase.scala
+++ b/base/src/main/scala/TCUBase.scala
@@ -16,9 +16,9 @@ object TCUBase {
     } = new TCU[C, T0[B0, A0]] {
       override type T[X] = T0[B0, X]
       override type A = A0
-      override val instance = TC0.instance.asInstanceOf[C[T]]
-      override val instanceTag = TC0.instanceTag
-      override val leibniz: T0[B0, A0] === T[A] = Leibniz.refl
+      override def instance = TC0.instance.asInstanceOf[C[T]]
+      override def instanceTag = TC0.instanceTag
+      override def leibniz: T0[B0, A0] === T[A] = Leibniz.refl
     }
 
     // OptionT
@@ -30,9 +30,9 @@ object TCUBase {
     } = new TCU[C, T0[F, A0]] {
       override type T[X] = T0[F, X]
       override type A = A0
-      override val instance = TC0.instance.asInstanceOf[C[T]]
-      override val instanceTag = TC0.instanceTag
-      override val leibniz: T0[F, A0] === T[A] = Leibniz.refl
+      override def instance = TC0.instance.asInstanceOf[C[T]]
+      override def instanceTag = TC0.instanceTag
+      override def leibniz: T0[F, A0] === T[A] = Leibniz.refl
     }
   }
 }

--- a/base/src/main/scala/clazz/Applicative.scala
+++ b/base/src/main/scala/clazz/Applicative.scala
@@ -8,7 +8,6 @@ abstract class Applicative[F[_]] {
 
 object Applicative {
   def apply[F[_]](implicit F: TC[F, Applicative]): Applicative[F] = F.instance
-  implicit def applicative[F[_]](implicit F: Applicative[F]): TC[F, Applicative] = TC[F, Applicative](F)
 
   object syntax extends ApplicativeSyntax
 }

--- a/base/src/main/scala/clazz/Apply.scala
+++ b/base/src/main/scala/clazz/Apply.scala
@@ -8,7 +8,6 @@ abstract class Apply[F[_]] {
 
 object Apply {
   def apply[F[_]](implicit F: TC[F, Apply]): Apply[F] = F.instance
-  implicit def apply_[M[_]](implicit M: Apply[M]): TC[M, Apply] = TC[M, Apply](M)
 
   object syntax extends ApplySyntax
 }

--- a/base/src/main/scala/clazz/Bind.scala
+++ b/base/src/main/scala/clazz/Bind.scala
@@ -8,7 +8,6 @@ abstract class Bind[M[_]] {
 
 object Bind extends BindInstances {
   def apply[F[_]](implicit F: TC[F, Bind]): Bind[F] = F.instance
-  implicit def bind[M[_]](implicit M: Bind[M]): TC[M, Bind] = TC[M, Bind](M)
 
   object syntax extends BindSyntax
 }

--- a/base/src/main/scala/clazz/BindRecInstances.scala
+++ b/base/src/main/scala/clazz/BindRecInstances.scala
@@ -6,8 +6,8 @@ import scala.annotation.tailrec
 import data.Disjunction.{\/, L_, R_}
 
 trait BindRecInstances {
-  implicit val bindRecIdentity: BindRec[Identity] = new BindRec[Identity] {
-    override val bind: Bind[Identity] = Monad.identity.bind
+  implicit val bindRecIdentity: TC[Identity, BindRec] = TC(new BindRec[Identity] {
+    override val bind: Bind[Identity] = Monad[Identity].bind
 
     @tailrec
     override def tailRecM[A, B](a: A)(f: A => Identity[A \/ B]): Identity[B] =
@@ -15,5 +15,5 @@ trait BindRecInstances {
         case Identity(L_(a0)) => tailRecM(a0)(f)
         case Identity(R_(b))  => Identity(b)
       }
-  }
+  })
 }

--- a/base/src/main/scala/clazz/Foldable.scala
+++ b/base/src/main/scala/clazz/Foldable.scala
@@ -10,7 +10,6 @@ abstract class Foldable[F[_]] {
 
 object Foldable extends FoldableInstances {
   def apply[F[_]](implicit F: TC[F, Foldable]): Foldable[F] = F.instance
-  implicit def foldable[F[_]](implicit F: Foldable[F]): TC[F, Foldable] = TC[F, Foldable](F)
 
   object syntax extends FoldableSyntax
 }

--- a/base/src/main/scala/clazz/FoldableInstances.scala
+++ b/base/src/main/scala/clazz/FoldableInstances.scala
@@ -2,10 +2,10 @@ package scato
 package clazz
 
 trait FoldableInstances {
-  implicit val list: Foldable[List] = new Foldable[List] {
+  implicit val list: TC[List, Foldable] = TC(new Foldable[List] {
     override def foldLeft[A, B](fa: List[A], z: B)(f: (B, A) => B): B = fa.foldLeft(z)(f)
     override def foldRight[A, B](fa: List[A], z: => B)(f: (A, => B) => B): B = fa.foldRight(z) { (a, b) => f(a, b) }
     override def toList[A](xs: List[A]): List[A] = xs
-  }
+  })
 }
 

--- a/base/src/main/scala/clazz/Functor.scala
+++ b/base/src/main/scala/clazz/Functor.scala
@@ -7,7 +7,6 @@ abstract class Functor[F[_]] {
 
 object Functor {
   def apply[F[_]](implicit F: TC[F, Functor]): Functor[F] = F.instance
-  implicit def functor[F[_]](implicit F: Functor[F]): TC[F, Functor] = TC[F, Functor](F)
 
   object syntax extends FunctorSyntax
 }

--- a/base/src/main/scala/clazz/MonadInstances.scala
+++ b/base/src/main/scala/clazz/MonadInstances.scala
@@ -2,7 +2,7 @@ package scato
 package clazz
 
 trait MonadInstances {
-  implicit val identity: Monad[Identity] = new Monad[Identity] {
+  implicit val identity: TC[Identity, Monad] = TC(new Monad[Identity] {
     override val applicative = new Applicative[Identity] {
       override val apply = new Apply[Identity] {
         override val functor = new Functor[Identity] {
@@ -17,5 +17,5 @@ trait MonadInstances {
       override def apply = applicative.apply
       override def flatMap[A, B](oa: Identity[A])(f: A => Identity[B]): Identity[B] = f(oa.run)
     }
-  }
+  })
 }

--- a/base/src/main/scala/clazz/MonadInstancesStdLib.scala
+++ b/base/src/main/scala/clazz/MonadInstancesStdLib.scala
@@ -2,7 +2,7 @@ package scato
 package clazz
 
 trait MonadInstancesStdLib {
-  implicit val option: Monad[Option] = new Monad[Option] {
+  implicit val option: TC[Option, Monad] = TC(new Monad[Option] {
     override val applicative = new Applicative[Option] {
       override val apply = new Apply[Option] {
         override val functor = new Functor[Option] {
@@ -17,9 +17,9 @@ trait MonadInstancesStdLib {
       override def apply = applicative.apply
       override def flatMap[A, B](oa: Option[A])(f: A => Option[B]): Option[B] = oa.flatMap(f)
     }
-  }
+  })
 
-  implicit val list: Monad[List] = new Monad[List] {
+  implicit val list: TC[List, Monad] = TC(new Monad[List] {
     override val applicative = new Applicative[List] {
       override val apply = new Apply[List] {
         override val functor = new Functor[List] {
@@ -34,5 +34,5 @@ trait MonadInstancesStdLib {
       override def apply = applicative.apply
       override def flatMap[A, B](xs: List[A])(f: A => List[B]): List[B] = xs.flatMap(f)
     }
-  }
+  })
 }

--- a/base/src/main/scala/clazz/TraversableInstances.scala
+++ b/base/src/main/scala/clazz/TraversableInstances.scala
@@ -6,13 +6,13 @@ import Apply.syntax._
 import Applicative.syntax._
 
 trait TraversableInstances {
-  implicit val list: Traversable[List] = new Traversable[List] {
-    override val functor = Monad.list.applicative.apply.functor
-    override val foldable = Foldable.list
+  implicit val list: TC[List, Traversable] = TC(new Traversable[List] {
+    override val functor = Monad[List].applicative.apply.functor
+    override val foldable = Foldable[List]
 
     override def traverse[F[_], A, B](ta: List[A])(f: A => F[B])(implicit F: TC[F, Applicative]): F[List[B]] =
       ta.foldLeft[F[List[B]]](List.empty[B].pure[F]) { (flb, a) => flb.ap(f(a).map(b => (xs: List[B]) => b::xs)) }
     override def sequence[F[_], A](ta: List[F[A]])(implicit F: TC[F, Applicative]): F[List[A]] =
       traverse[F, F[A], A](ta)(identity)
-  }
+  })
 }

--- a/base/src/main/scala/data/Disjunction.scala
+++ b/base/src/main/scala/data/Disjunction.scala
@@ -9,10 +9,11 @@ sealed trait Disjunction[+L, +R] {
   }
 }
 
-object Disjunction extends DisjunctionInstances {
+object Disjunction extends DisjunctionInstances with DisjunctionFunctions{
   object Syntax extends DisjunctionSyntax
 
   type \/[L, R] = Disjunction[L, R]
+
   case class L_[L](value: L) extends (L \/ Nothing)
   case class R_[R](value: R) extends (Nothing \/ R)
 

--- a/base/src/main/scala/data/DisjunctionFunctions.scala
+++ b/base/src/main/scala/data/DisjunctionFunctions.scala
@@ -1,0 +1,8 @@
+package scato
+package data
+
+trait DisjunctionFunctions {
+  // TODO Can be inlined?
+  def left[L](value: L): Disjunction[L, Nothing] = Disjunction.L_(value)
+  def right[R](value: R): Disjunction[Nothing, R] = Disjunction.R_(value)
+}

--- a/base/src/main/scala/data/DisjunctionInstances.scala
+++ b/base/src/main/scala/data/DisjunctionInstances.scala
@@ -5,7 +5,7 @@ import clazz._
 import Disjunction.{\/, L_, R_}
 
 trait DisjunctionInstances {
-  implicit def monad[L]: Monad[L \/ ?] = new Monad[L \/ ?] {
+  implicit def monad[L]: TC[L \/ ?, Monad] = TC.capture[L \/ ?, Monad, Any \/ ?](new Monad[L \/ ?] {
     override val applicative = new Applicative[L \/ ?] {
       override val apply = new Apply[L \/ ?] {
         override val functor = new Functor[L \/ ?] {
@@ -24,10 +24,10 @@ trait DisjunctionInstances {
       override def flatMap[A, B](oa: L \/ A)(f: A => L \/ B): L \/ B =
         oa.fold[L \/ B](l => L_(l))(a => f(a))
     }
-  }
+  })
 
-  implicit def applicativeTC[L]: TC[L \/ ?, Applicative] = TC[L \/ ?, Applicative](monad.applicative)
-  implicit def applyTC[L]: TC[L \/ ?, Apply] = TC[L \/ ?, Apply](monad.applicative.apply)
-  implicit def functorTC[L]: TC[L \/ ?, Functor] = TC[L \/ ?, Functor](monad.applicative.apply.functor)
-  implicit def bindTC[L]: TC[L \/ ?, Bind] = TC[L \/ ?, Bind](monad.bind)
+  implicit def applicativeTC[L]: TC[L \/ ?, Applicative] = TC[L \/ ?, Applicative](monad[L].instance.applicative)
+  implicit def applyTC[L]: TC[L \/ ?, Apply] = TC[L \/ ?, Apply](monad[L].instance.applicative.apply)
+  implicit def functorTC[L]: TC[L \/ ?, Functor] = TC[L \/ ?, Functor](monad[L].instance.applicative.apply.functor)
+  implicit def bindTC[L]: TC[L \/ ?, Bind] = TC[L \/ ?, Bind](monad[L].instance.bind)
 }

--- a/base/src/main/scala/data/DisjunctionInstances.scala
+++ b/base/src/main/scala/data/DisjunctionInstances.scala
@@ -5,7 +5,8 @@ import clazz._
 import Disjunction.{\/, L_, R_}
 
 trait DisjunctionInstances {
-  implicit def monad[L]: TC[L \/ ?, Monad] = TC.capture[L \/ ?, Monad, Any \/ ?](new Monad[L \/ ?] {
+  //implicit def monad[L]: TC[L \/ ?, Monad] = TC.capture[L \/ ?, Monad, Any \/ ?](new Monad[L \/ ?] {
+  implicit def monad[L]: TC[L \/ ?, Monad] = TC[L \/ ?, Monad](new Monad[L \/ ?] {
     override val applicative = new Applicative[L \/ ?] {
       override val apply = new Apply[L \/ ?] {
         override val functor = new Functor[L \/ ?] {

--- a/base/src/main/scala/data/MaybeInstances.scala
+++ b/base/src/main/scala/data/MaybeInstances.scala
@@ -5,7 +5,7 @@ import clazz._
 import Maybe.{Just, Empty}
 
 trait MaybeInstances {
-  implicit val monad: Monad[Maybe] = new Monad[Maybe] {
+  implicit val monad: TC[Maybe, Monad] = TC(new Monad[Maybe] {
     override val applicative = new Applicative[Maybe] {
       override val apply = new Apply[Maybe] {
         override val functor = new Functor[Maybe] {
@@ -23,5 +23,5 @@ trait MaybeInstances {
       override def flatMap[A, B](oa: Maybe[A])(f: A => Maybe[B]): Maybe[B] =
         oa.fold(a => f(a), Empty())
     }
-  }
+  })
 }

--- a/examples/src/main/scala/Caching.scala
+++ b/examples/src/main/scala/Caching.scala
@@ -1,0 +1,20 @@
+package scato
+package examples
+
+import Prelude._
+
+object Caching {
+
+  def doIt(): Unit = {
+    val xs: List[Int] = (0 to 128).toList
+    val f: Int => String \/ Int = i => right(i)
+    xs.traverse(f)
+  }
+
+  def doItMoreTimes(): Unit = {
+    (0 to 128).foreach { _ =>
+      doIt()
+    }
+  }
+}
+

--- a/free/src/main/scala/monad/FreeInstances.scala
+++ b/free/src/main/scala/monad/FreeInstances.scala
@@ -7,7 +7,8 @@ import clazz.{Apply, Applicative, Bind, BindRec, Functor, Monad}
 trait FreeInstances {
 
   implicit def freeBind[F[_]](implicit F: TC[F, Functor]): TC[Free[F, ?], Bind] =
-    TC.capture[Free[F, ?], Bind, Free[Any, ?]](new Bind[Free[F, ?]] {
+    //TC.capture[Free[F, ?], Bind, Free[Any, ?]](new Bind[Free[F, ?]] {
+    TC[Free[F, ?], Bind](new Bind[Free[F, ?]] {
       override val apply = new Apply[Free[F, ?]] {
         override val functor = new Functor[Free[F, ?]] {
           override def map[A, B](fa: Free[F, A])(f: A => B): Free[F, B] = fa.map(f)
@@ -28,7 +29,8 @@ trait FreeInstances {
   */
 
   implicit def freeMonad[F[_]](implicit F: TC[F, Functor]): TC[Free[F, ?], Monad] =
-    TC.capture[Free[F, ?], Monad, Free[Any, ?]](new Monad[Free[F, ?]] {
+    // TC.capture[Free[F, ?], Monad, Free[Any, ?]](new Monad[Free[F, ?]] {
+    TC[Free[F, ?], Monad](new Monad[Free[F, ?]] {
       override val bind = freeBind[F].instance
       override val applicative = new Applicative[Free[F, ?]] {
         override val apply = freeBind[F].instance.apply

--- a/free/src/main/scala/monad/FreeInstances.scala
+++ b/free/src/main/scala/monad/FreeInstances.scala
@@ -5,16 +5,18 @@ package monad
 import clazz.{Apply, Applicative, Bind, BindRec, Functor, Monad}
 
 trait FreeInstances {
-  implicit def freeBind[F[_]](implicit F: TC[F, Functor]): Bind[Free[F, ?]] = new Bind[Free[F, ?]] {
-    override val apply = new Apply[Free[F, ?]] {
-      override val functor = new Functor[Free[F, ?]] {
-        override def map[A, B](fa: Free[F, A])(f: A => B): Free[F, B] = fa.map(f)
-      }
-      override def ap[A, B](fa: Free[F, A])(fab: Free[F, A => B]): Free[F, B] = fa.ap(fab)
-    }
 
-    override def flatMap[A, B](fa: Free[F, A])(fb: A => Free[F, B]): Free[F, B] = fa.flatMap(fb)
-  }
+  implicit def freeBind[F[_]](implicit F: TC[F, Functor]): TC[Free[F, ?], Bind] =
+    TC.capture[Free[F, ?], Bind, Free[Any, ?]](new Bind[Free[F, ?]] {
+      override val apply = new Apply[Free[F, ?]] {
+        override val functor = new Functor[Free[F, ?]] {
+          override def map[A, B](fa: Free[F, A])(f: A => B): Free[F, B] = fa.map(f)
+        }
+        override def ap[A, B](fa: Free[F, A])(fab: Free[F, A => B]): Free[F, B] = fa.ap(fab)
+      }
+
+      override def flatMap[A, B](fa: Free[F, A])(fb: A => Free[F, B]): Free[F, B] = fa.flatMap(fb)
+    })
 
   // TODO Implement bindRec instance
   /*
@@ -25,12 +27,13 @@ trait FreeInstances {
   }
   */
 
-  implicit def freeMonad[F[_]](implicit F: TC[F, Functor]): Monad[Free[F, ?]] = new Monad[Free[F, ?]] {
-    override val bind = freeBind[F]
-    override val applicative = new Applicative[Free[F, ?]] {
-      override val apply = bind.apply
-      override def pure[A](a: A): Free[F, A] = Free(Algebra.Thunk.pure[A](_ => a))
-    }
-  }
+  implicit def freeMonad[F[_]](implicit F: TC[F, Functor]): TC[Free[F, ?], Monad] =
+    TC.capture[Free[F, ?], Monad, Free[Any, ?]](new Monad[Free[F, ?]] {
+      override val bind = freeBind[F].instance
+      override val applicative = new Applicative[Free[F, ?]] {
+        override val apply = freeBind[F].instance.apply
+        override def pure[A](a: A): Free[F, A] = Free(Algebra.Thunk.pure[A](_ => a))
+      }
+    })
 }
 

--- a/prelude/src/main/scala/Prelude.scala
+++ b/prelude/src/main/scala/Prelude.scala
@@ -4,7 +4,9 @@ import clazz._
 
 import scala.language.implicitConversions
 
-trait Prelude {
+trait Prelude extends data.DisjunctionFunctions {
+  type \/[L, R] = data.Disjunction.\/[L, R]
+
   // FunctorSyntax
   implicit def PfunctorOps[F[_], A](fa: F[A])(implicit F: TC[F, Functor]): FunctorSyntax.Ops[F, A] =
     new FunctorSyntax.Ops(fa)(F.instance)
@@ -28,6 +30,13 @@ trait Prelude {
 
   // ApplicativeSyntax
   implicit def PapplicativeOpsA[A](a: A): ApplicativeSyntax.OpsA[A] = new ApplicativeSyntax.OpsA(a)
+
+  // TraversableSyntax
+  implicit def traversableOps[T[_], A](ta: T[A])(implicit T: TC[T, Traversable]): TraversableSyntax.Ops[T, A] =
+    new TraversableSyntax.Ops(ta)(T.instance)
+
+  implicit def traversable[T[_], TA](ta: TA)(implicit T: TCU[Traversable, TA]): TraversableSyntax.Ops[T.T, T.A] =
+    new TraversableSyntax.Ops(T(ta))(T.instance)
 }
 
 object Prelude extends Prelude

--- a/profunctors/src/main/scala/ChoiceInstances.scala
+++ b/profunctors/src/main/scala/ChoiceInstances.scala
@@ -4,9 +4,9 @@ package profunctors
 import data.Disjunction.{\/, L_, R_}
 
 trait ChoiceInstances {
-  implicit val function: Choice[Function] = new Choice[Function] {
-    val profunctor = Profunctor.function
+  implicit val function: TC2[Function, Choice] = TC2(new Choice[Function] {
+    val profunctor = Profunctor[Function]
     override def left[A, B, C](ab: A => B): A \/ C => B \/ C  = _.fold[B \/ C](a => L_(ab(a)))(R_(_))
     override def right[A, B, C](ab: A => B): C \/ A => C \/ B = _.fold[C \/ B](L_(_))((a => R_(ab(a))))
-  }
+  })
 }

--- a/profunctors/src/main/scala/ProfunctorInstances.scala
+++ b/profunctors/src/main/scala/ProfunctorInstances.scala
@@ -2,9 +2,9 @@ package scato
 package profunctors
 
 trait ProfunctorInstances { instances =>
-  implicit val function: Profunctor[Function] = new Profunctor[Function] {
+  implicit val function: TC2[Function, Profunctor] = TC2(new Profunctor[Function] {
     override def lmap[A, B, C](ab: A => B)(ca: C => A): C => B = c => ab(ca(c))
     override def rmap[A, B, C](ab: A => B)(bc: B => C): A => C = a => bc(ab(a))
     override def dimap[A, B, C, D](ab: A => B)(ca: C => A)(bd: B => D): C => D = c => bd(ab(ca(c)))
-  }
+  })
 }

--- a/project/ScatoBuild.scala
+++ b/project/ScatoBuild.scala
@@ -26,7 +26,13 @@ object ScatoBuild extends Build {
               , prelude
               , examples )
 
-  lazy val typeclass    = module("typeclass")
+  lazy val typeclass    = module("typeclass").settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang"  %  "scala-reflect"  % scalaVersion.value,
+      "org.scala-lang"  %  "scala-compiler" % scalaVersion.value % "provided"
+    )
+  )
+
   lazy val baze         = module("base").dependsOn(typeclass)
 
   lazy val free         = module("free").dependsOn(baze)

--- a/typeclass/src/main/scala/package.scala
+++ b/typeclass/src/main/scala/package.scala
@@ -1,6 +1,6 @@
 package scato
 
-import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
 import scala.collection.concurrent.TrieMap
 
 import Leibniz.===
@@ -16,7 +16,7 @@ abstract class ~~>>[A[_[_, _]], B[_[_, _]]] {
 abstract class TC[T[_], C[_[_]]] {
   def instance: C[T]
   def instanceTag: Int
-  def map[D[_[_]]](f: C ~~> D)(implicit DT: ClassTag[D[T]]): TC[T, D] = TC(f(instance))
+  def map[D[_[_]]](f: C ~~> D): TC[T, D] = TC(f(instance))
 }
 
 object TC {
@@ -28,7 +28,7 @@ object TC {
       override def instanceTag = 0
     }
 
-  def capture[T[_], C[_[_]], ID[_]](i: => C[T])(implicit CT: ClassTag[C[ID]]): TC[T, C] =
+  def capture[T[_], C[_[_]], ID[_]](i: => C[T])(implicit CT: TypeTag[C[ID]]): TC[T, C] =
     new TC[T, C] {
       override def instance = cache.getOrElseUpdate(instanceTag, i).asInstanceOf[C[T]]
       override def instanceTag = CT.hashCode

--- a/typeclass/src/main/scala/package.scala
+++ b/typeclass/src/main/scala/package.scala
@@ -24,8 +24,8 @@ object TC {
 
   def apply[T[_], C[_[_]]](i: C[T])(implicit CT: ClassTag[C[T]]): TC[T, C] =
     new TC[T, C] {
-      override val instance = cache.getOrElseUpdate(CT.hashCode, i).asInstanceOf[C[T]]
-      override val instanceTag = CT
+      override def instance = cache.getOrElseUpdate(CT.hashCode, i).asInstanceOf[C[T]]
+      override def instanceTag = CT
     }
 }
 
@@ -52,9 +52,9 @@ object TCU {
   } = new TCU[C, T0[A0]] {
     override type T[X] = T0[X]
     override type A = A0
-    override val instance: C[T] = TC0.instance
-    override val instanceTag: ClassTag[C[T]] = TC0.instanceTag
-    override val leibniz: T0[A0] === T[A] = Leibniz.refl
+    override def instance: C[T] = TC0.instance
+    override def instanceTag: ClassTag[C[T]] = TC0.instanceTag
+    override def leibniz: T0[A0] === T[A] = Leibniz.refl
   }
 }
 

--- a/typeclass/src/main/scala/package.scala
+++ b/typeclass/src/main/scala/package.scala
@@ -27,6 +27,12 @@ object TC {
       override def instance = cache.getOrElseUpdate(CT.hashCode, i).asInstanceOf[C[T]]
       override def instanceTag = CT
     }
+
+  def pure[T[_], C[_[_]]](i: C[T])(implicit CT: ClassTag[C[T]]): TC[T, C] =
+    new TC[T, C] {
+      override def instance = i
+      override def instanceTag = CT
+    }
 }
 
 

--- a/typeclass/src/main/scala/package.scala
+++ b/typeclass/src/main/scala/package.scala
@@ -15,23 +15,23 @@ abstract class ~~>>[A[_[_, _]], B[_[_, _]]] {
 
 abstract class TC[T[_], C[_[_]]] {
   def instance: C[T]
-  def instanceTag: Int
+  def instanceTag: TypeTag[_]
   def map[D[_[_]]](f: C ~~> D): TC[T, D] = TC(f(instance))
 }
 
 object TC {
-  private val cache: TrieMap[Int, Any] = TrieMap()
+  private val cache: TrieMap[TypeTag[_], Any] = TrieMap()
 
   def apply[T[_], C[_[_]]](i: C[T]): TC[T, C] =
     new TC[T, C] {
       override def instance = i
-      override def instanceTag = 0
+      override def instanceTag = null
     }
 
   def capture[T[_], C[_[_]], ID[_]](i: => C[T])(implicit CT: TypeTag[C[ID]]): TC[T, C] =
     new TC[T, C] {
       override def instance = cache.getOrElseUpdate(instanceTag, i).asInstanceOf[C[T]]
-      override def instanceTag = CT.hashCode
+      override def instanceTag = CT
     }
 }
 
@@ -44,7 +44,7 @@ trait TCU[C[_[_]], TA] {
   type T[_]
   type A
   def instance: C[T]
-  def instanceTag: Int
+  def instanceTag: TypeTag[_]
   def leibniz: TA === T[A]
 
   def apply(ta: TA): T[A] = leibniz(ta)


### PR DESCRIPTION
Here is a protype of a caching system for `TC`s. /cc @jbgi

It's not clear to me how bad this is, and when it should really be used.

Clearly not on the `val`, I did introduce it on `Disjunction` and having `println`ed the instantion and run the `Caching` examples I can definitely confirm it works.

This open lot of question about the tradeoff of using such approach vs the performance impact of such a global cache.

@ijuma if you get a chance to take a look, basically I'm using a `TrieMap` to cache generic typeclass instances (identifying using the hashcode of the `ClassTag` of the generic type), I suppose that could have bad consequences in a highly concurrent setting? or is that fine as the map will be only written when the program warmup, and then only read?
